### PR TITLE
Replace gen_event with logger_filter

### DIFF
--- a/lib/shoehorn/application.ex
+++ b/lib/shoehorn/application.ex
@@ -5,13 +5,13 @@ defmodule Shoehorn.Application do
 
   @impl Application
   def start(_type, _args) do
+    env = Application.get_all_env(:shoehorn)
     if using_shoehorn?() do
-      opts = Application.get_all_env(:shoehorn)
-      :error_logger.add_report_handler(Shoehorn.ReportHandler, opts)
+      Shoehorn.ReportHandler.init_handler()
     end
 
     opts = [strategy: :one_for_one, name: Shoehorn.Supervisor]
-    Supervisor.start_link([], opts)
+    Supervisor.start_link([{Shoehorn.ReportHandler, env}], opts)
   end
 
   defp using_shoehorn?() do

--- a/lib/shoehorn/filter.ex
+++ b/lib/shoehorn/filter.ex
@@ -1,0 +1,40 @@
+defmodule Shoehorn.Filter do
+  @moduledoc false
+
+  @doc """
+  A filter for handling Application.start/1,2 and Application.stop/1 events. Always return :ignore so that other filters
+  can continue to handle the events as they please.
+  """
+  def filter(_event = %{msg: msg}, _extra) do
+    maybe_log_message(msg)
+    :ignore
+  end
+
+  def filter(_event, _extra) do
+    :ignore
+  end
+
+  def maybe_log_message(
+        {:report,
+         %{
+           label: {:application_controller, :progress},
+           report: [application: app, started_at: _node]
+         }}
+      ) do
+    GenServer.cast(Shoehorn.ReportHandler, {:started, app})
+  end
+
+  def maybe_log_message(
+        {:report,
+         %{
+           label: {:application_controller, :exit},
+           report: [application: app, exited: reason, type: _type]
+         }}
+      ) do
+    GenServer.cast(Shoehorn.ReportHandler, {:exit, app, reason})
+  end
+
+  def maybe_log_message(_msg) do
+    :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Shoehorn.MixProject do
     [
       app: :shoehorn,
       version: @version,
-      elixir: "~> 1.10",
+      elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),
       description: description(),


### PR DESCRIPTION
Elixir 1.15 brought in a lot of changes to logging, particularly around its use of :error_logger. Reports were no longer being received in Shoehorn.ReportHandler. To get around this, we set up a logger_filter that checks for application starts and stop, handles them if necessary, and then lets the other logger filters work as they normally would.

We also make Shoehorn.ReportHandler a GenServer for 2 reasons:
    1. To handle the state
    2. If the user was to run an Application call in their callback, they will get a crash about a process calling itself. So the call must be done from a separate process because we will get errors about trying to start an application

Lastly, bump up the min Elixir version